### PR TITLE
Discriminate production or debug mode for SGX RA. issue #28:

### DIFF
--- a/ias-verify/src/tests.rs
+++ b/ias-verify/src/tests.rs
@@ -79,6 +79,7 @@ fn verify_ias_report_should_work() {
     assert_eq!(report.pubkey, TEST4_SIGNER_PUB);
     //assert_eq!(report.status, SgxStatus::GroupOutOfDate);
     assert_eq!(report.status, SgxStatus::ConfigurationNeeded);
+    assert_eq!(report.build_mode, SgxBuildMode::Debug);
 }
 
 #[test]
@@ -131,4 +132,13 @@ fn fix_incorrect_handling_of_iterator() {
     ];
 
     assert_err!(verify_ias_report(&report), "Invalid netscape payload");
+}
+
+#[test]
+fn verify_sgx_build_mode_works() {
+    //verify report from enclave in debug mode
+    let report = verify_ias_report(TEST4_CERT);
+    let report = report.unwrap();
+    assert_eq!(report.build_mode, SgxBuildMode::Debug);
+    //TODO assert report not in SGX_MODE HW debug.
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -135,13 +135,38 @@ impl Config for Test {
 }
 
 // This function basically just builds a genesis storage key/value store according to
-// our desired mockup.
+// our desired mockup. RA from enclave compiled in debug mode is allowed
 pub fn new_test_ext() -> sp_io::TestExternalities {
     let mut t = system::GenesisConfig::default()
         .build_storage::<Test>()
         .unwrap();
     pallet_balances::GenesisConfig::<Test> {
         balances: vec![(AccountKeyring::Alice.to_account_id(), 1 << 60)],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+    crate::GenesisConfig {
+        allow_sgx_debug_mode: true,
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+    let mut ext: sp_io::TestExternalities = t.into();
+    ext.execute_with(|| System::set_block_number(1));
+    ext
+}
+
+//Build genesis storage for mockup, where RA from enclave compiled in debug mode is NOT allowed
+pub fn new_test_production_ext() -> sp_io::TestExternalities {
+    let mut t = system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+    pallet_balances::GenesisConfig::<Test> {
+        balances: vec![(AccountKeyring::Alice.to_account_id(), 1 << 60)],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+    crate::GenesisConfig {
+        allow_sgx_debug_mode: false,
     }
     .assimilate_storage(&mut t)
     .unwrap();


### PR DESCRIPTION
Add a genesis config field: allow_sgx_debug_mode to configure if a debug-mode can attest